### PR TITLE
rename platform define from "UNITY_GAME_CORE" to "UNITY_GAMECORE"

### DIFF
--- a/Package/Assets/GDK-Tools/Examples/In Game Store/SampleInGamePurchasableItem.cs
+++ b/Package/Assets/GDK-Tools/Examples/In Game Store/SampleInGamePurchasableItem.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using Microsoft.Xbox;
 
-#if UNITY_GAME_CORE
+#if UNITY_GAMECORE
 using Unity.GameCore;
 #endif
 #if MICROSOFT_GAME_CORE
@@ -20,7 +20,7 @@ public class SampleInGamePurchasableItem : MonoBehaviour {
 	public Text priceUIElement;
     public Text ownedUIElement;
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
     private XStoreProduct storeProduct;
 
     public void UpdateUI(XStoreProduct product)
@@ -34,12 +34,12 @@ public class SampleInGamePurchasableItem : MonoBehaviour {
 
     public void Purchase()
     {
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
         Gdk.Helpers.ShowPurchaseUIAsync(storeProduct, ShowPurchaseCallback);
 #endif
     }
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
     public void ShowPurchaseCallback(int hresult, XStoreProduct product)
     {
         if (hresult >= 0)

--- a/Package/Assets/GDK-Tools/Examples/In Game Store/StoreSampleLogic.cs
+++ b/Package/Assets/GDK-Tools/Examples/In Game Store/StoreSampleLogic.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Microsoft.Xbox;
 
-#if UNITY_GAME_CORE
+#if UNITY_GAMECORE
 using Unity.GameCore;
 #endif
 #if MICROSOFT_GAME_CORE
@@ -25,13 +25,13 @@ public class StoreSampleLogic : MonoBehaviour {
 
     public void ShowDLC()
     {
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
         // Get the list of In game purchasable items.
         Gdk.Helpers.GetAssociatedProductsAsync(GetAssociatedProductsAsyncCallback);
 #endif        
     }
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
     public void GetAssociatedProductsAsyncCallback(Int32 hresult, List<XStoreProduct> associatedProducts)
     {
         for (int i = 0; i < associatedProducts.Count; i++)

--- a/Package/Assets/GDK-Tools/Source/Scripts/Gdk.cs
+++ b/Package/Assets/GDK-Tools/Source/Scripts/Gdk.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#if UNITY_GAME_CORE
+#if UNITY_GAMECORE
 using Unity.GameCore;
 #endif
 #if MICROSOFT_GAME_CORE
@@ -36,7 +36,7 @@ namespace Microsoft.Xbox
         }
     }
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
     public delegate void ShowPurchaseUICallback(Int32 hresult, XStoreProduct storeProduct);
     public delegate void GetAssociatedProductsCallback(Int32 hresult, List<XStoreProduct> associatedProducts);
 #endif
@@ -52,7 +52,7 @@ namespace Microsoft.Xbox
         private static bool _initialized;
         private static Dictionary<int, string> _hresultToFriendlyErrorLookup;
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
         private XStoreContext _storeContext = null;
         private XUserHandle _userHandle;
         private XblContextHandle _xblContextHandle;
@@ -121,7 +121,7 @@ namespace Microsoft.Xbox
 
             DontDestroyOnLoad(gameObject);
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
             if (!Succeeded(SDK.XGameRuntimeInitialize(), "Initialize gaming runtime"))
             {
                 return;
@@ -153,14 +153,14 @@ namespace Microsoft.Xbox
 
         public void SignIn()
         {
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
             SignInImpl();
 #endif
         }
 
         public void Save(byte[] data)
         {
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
             _gameSaveHelper.Save(
                 _GameSaveContainerName,
                 _GameSaveBlobName,
@@ -171,7 +171,7 @@ namespace Microsoft.Xbox
 
         public void LoadSaveData()
         {
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
             _gameSaveHelper.Load(
                 _GameSaveContainerName,
                 _GameSaveBlobName,
@@ -181,12 +181,12 @@ namespace Microsoft.Xbox
 
         public void UnlockAchievement(string achievementId)
         {
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
             UnlockAchievementImpl(achievementId);
 #endif
         }
 
-#if MICROSOFT_GAME_CORE || UNITY_GAME_CORE
+#if MICROSOFT_GAME_CORE || UNITY_GAMECORE
         private void SignInImpl()
         {
             XUserAddOptions options = XUserAddOptions.AddDefaultUserAllowingUI;
@@ -370,7 +370,7 @@ namespace Microsoft.Xbox
         // Update is called once per frame
         void Update()
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             SDK.XTaskQueueDispatch();
 #endif
         }

--- a/Package/Assets/GDK-Tools/Source/Scripts/XGameSaveWrapper.cs
+++ b/Package/Assets/GDK-Tools/Source/Scripts/XGameSaveWrapper.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-#if UNITY_GAME_CORE
+#if UNITY_GAMECORE
 using Unity.GameCore;
 #endif
 #if MICROSOFT_GAME_CORE
@@ -15,7 +15,7 @@ namespace Microsoft.Xbox
 {
     public class XGameSaveWrapper
     {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE)
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE)
         private XUserHandle m_userHandle;
         private XGameSaveProviderHandle m_gameSaveProviderHandle;
 #else
@@ -27,7 +27,7 @@ namespace Microsoft.Xbox
 
         ~XGameSaveWrapper()
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE)
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE)
             SDK.XGameSaveCloseProvider(m_gameSaveProviderHandle);
             SDK.XUserCloseHandle(m_userHandle);
 #endif
@@ -47,7 +47,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. InitializeCallback(Int32 hresult)</param>
         public void InitializeAsync(XUserHandle userHandle, string scid, InitializeCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             Int32 hr = SDK.XUserDuplicateHandle(userHandle, out m_userHandle);
             if (HR.FAILED(hr))
             {
@@ -78,7 +78,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. GetQuotaCallback(Int32 hresult, Int64 remainingQuota)</param>
         public void GetQuotaAsync(GetQuotaCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             SDK.XGameSaveGetRemainingQuotaAsync(m_gameSaveProviderHandle, new XGameSaveGetRemainingQuotaCompleted(callback));
 #else
             callback(0, 0);
@@ -100,7 +100,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. QueryContainersCallback(Int32 hresult, string[] containerNames)</param>
         public void QueryContainers(string containerNamePrefix, QueryContainersCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             XGameSaveContainerInfo[] containerInfos;
             Int32 hr = SDK.XGameSaveEnumerateContainerInfoByName(m_gameSaveProviderHandle, containerNamePrefix, out containerInfos);
 
@@ -134,7 +134,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. QueryBlobsCallback(Int32 hresult, Dictionary<string, UInt32> blobInfos)</param>
         public void QueryContainerBlobs(string containerName, QueryBlobsCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             XGameSaveContainerHandle containerHandle;
             Int32 hr = SDK.XGameSaveCreateContainer(m_gameSaveProviderHandle, containerName, out containerHandle);
             if (HR.FAILED(hr))
@@ -176,7 +176,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. LoadCallback(Int32 hresult, byte[] blobData)</param>
         public void Load(string containerName, string blobName, LoadCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             XGameSaveContainerHandle containerHandle;
             Int32 hr = SDK.XGameSaveCreateContainer(m_gameSaveProviderHandle, containerName, out containerHandle);
             if (HR.FAILED(hr))
@@ -221,7 +221,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. SaveCallback(Int32 hresult)</param>
         public void Save(string containerName, string blobName, byte[] blobData, SaveCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             Dictionary<string, byte[]> blobsToSave = new Dictionary<string, byte[]>();
             blobsToSave.Add(blobName, blobData);
             Update(containerName, blobsToSave, null, new UpdateCallback(callback));
@@ -243,7 +243,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. DeleteCallback(Int32 hresult)</param>
         public void Delete(string containerName, DeleteCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             SDK.XGameSaveDeleteContainerAsync(m_gameSaveProviderHandle, containerName, new XGameSaveDeleteContainerCompleted(callback));
 #else
             callback(0);
@@ -258,7 +258,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. DeleteCallback(Int32 hresult)</param>
         public void Delete(string containerName, string blobName, DeleteCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             Delete(containerName, new string[1] { blobName }, callback);
 #else
             callback(0);
@@ -273,7 +273,7 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. DeleteCallback(Int32 hresult)</param>
         public void Delete(string containerName, string[] blobNames, DeleteCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             Update(containerName, null, blobNames, new UpdateCallback(callback));
 #else
             callback(0);
@@ -285,7 +285,7 @@ namespace Microsoft.Xbox
         private delegate void UpdateCallback(Int32 hresult);
         private void Update(string containerName, IDictionary<string, byte[]> blobsToSave, IList<string> blobsToDelete, UpdateCallback callback)
         {
-#if (MICROSOFT_GAME_CORE || UNITY_GAME_CORE) && !UNITY_EDITOR
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             XGameSaveContainerHandle containerHandle;
             Int32 hr = SDK.XGameSaveCreateContainer(m_gameSaveProviderHandle, containerName, out containerHandle);
             if (HR.FAILED(hr))
@@ -294,7 +294,7 @@ namespace Microsoft.Xbox
             }
 
             XGameSaveUpdateHandle updateHandle;
-            hr = SDK.XGameSaveCreateUpdate(containerHandle, null, out updateHandle);
+            hr = SDK.XGameSaveCreateUpdate(containerHandle, containerName, out updateHandle);
             if (HR.FAILED(hr))
             {
                 SDK.XGameSaveCloseContainer(containerHandle);


### PR DESCRIPTION
This change renames the platform define "UNITY_GAME_CORE" to "UNITY_GAMECORE" to match the latest naming used elsewhere.

This also contains a minor fix to XGameSaveWrapper.