### PR TITLE
Micopley/xbl real time activity unity script impls

### DIFF
--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/InteropCallbackManager.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/InteropCallbackManager.cs
@@ -4,7 +4,8 @@ using System.Runtime.InteropServices;
 
 namespace XGamingRuntime.Interop
 {
-    public class InteropCallbackManager<TDelegate> where TDelegate : Delegate
+    // should be TDelegate : Delegate, but that is not available until C# 7
+    public class InteropCallbackManager<TDelegate> where TDelegate : class
     {
         protected struct HandlerContext
         {

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/InteropCallbackManager.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/InteropCallbackManager.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace XGamingRuntime.Interop
+{
+    public class InteropCallbackManager<TDelegate> where TDelegate : Delegate
+    {
+        protected struct HandlerContext
+        {
+            public IntPtr Context;
+            public TDelegate Callback;
+        }
+
+        protected readonly Dictionary<IntPtr, int> _contextToFunctionId =
+            new Dictionary<IntPtr, int>();
+        protected readonly Dictionary<int, HandlerContext> _functionIdToHandler =
+            new Dictionary<int, HandlerContext>();
+
+        private int _availableContextId = 1000;
+
+        internal IntPtr GetUniqueContext()
+        {
+            return new IntPtr(_availableContextId++);
+        }
+
+        internal void AddCallbackForId(
+            int functionId,
+            IntPtr context,
+            TDelegate callback)
+        {
+            _contextToFunctionId[context] = functionId;
+            _functionIdToHandler[functionId] = new HandlerContext()
+            {
+                Context = context,
+                Callback = callback
+            };
+        }
+
+        internal void RemoveCallbackForId(int functionId)
+        {
+            if (!_functionIdToHandler.ContainsKey(functionId))
+            {
+                return;
+            }
+
+            var eventHandler = _functionIdToHandler[functionId];
+
+            _contextToFunctionId.Remove(eventHandler.Context);
+            _functionIdToHandler.Remove(functionId);
+        }
+    }
+}

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe58acef32af18745abd79f6a6a1f6e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/Multiplayer.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/Multiplayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0c39e7e718c9d24688762c4fb0a740f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/XblMultiplayerSessionQuery.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/XblMultiplayerSessionQuery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0058c6c9c1f2dc84794cf3ff937857a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/XblMultiplayerSessionQueryResult.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/XblMultiplayerSessionQueryResult.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3848ee9856ef7b44f96dcb5ced15afb6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/XblMultiplayerSessionStatus.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Multiplayer/XblMultiplayerSessionStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa1f0f7f0fa4e6f468bd1586a2c34fd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialNotificationType.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialNotificationType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe51ab8ec336c8a408cf92f2e6b0a1f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationship.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationship.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03fb86f9a007788479245757f9f13b4f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationshipChangeEventArgs.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationshipChangeEventArgs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8b1f79b2cebb434fabad630adf80038
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationshipChangedHandler.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationshipChangedHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f341c41bec155041a17e6b775c3c128
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationshipFilter.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/Interop/__GENERATED/XBL/Social/XblSocialRelationshipFilter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05816d3a92867dc4aa3e572258746b71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Matchmaking.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Matchmaking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6ac351fac4fd7342a0b0fd686ede927
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Matchmaking/XblMatchmaking.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Matchmaking/XblMatchmaking.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 629e1cedfd930ec4381aa17f37043b08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 85e95070dd94f0641a7c8604a0d08d8c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs
@@ -1,0 +1,97 @@
+using System;
+using XGamingRuntime.Interop;
+
+namespace XGamingRuntime
+{
+    public struct XblRealTimeActivityCallbackToken
+    {
+        public const int InvalidHandlerId = 0;
+
+        public int InteropHandlerId;
+
+        public void Reset() { InteropHandlerId = InvalidHandlerId; }
+        public bool IsValid() { return InteropHandlerId > InvalidHandlerId; }
+    }
+
+    public delegate void XblConnectionStateChangeCallback(XblRealTimeActivityConnectionState newConnectionState);
+
+    public delegate void XblConnectionResyncCallback();
+
+    public partial class SDK
+    {
+        public partial class XBL
+        {
+            public static XblRealTimeActivityCallbackToken XblRealTimeActivityAddConnectionStateChangeHandler(
+                XblContextHandle xboxLiveContext,
+                XblConnectionStateChangeCallback callback)
+            {
+                int interopHandlerId = XblRealTimeActivityCallbackToken.InvalidHandlerId;
+
+                if (callback != null)
+                {
+                    interopHandlerId = RealTimeActivity.XblRealTimeActivityAddConnectionStateChangeHandler(
+                        xboxLiveContext.InteropHandle.handle,
+                        (IntPtr context, XblRealTimeActivityConnectionState connectionState) =>
+                        {
+                            callback?.Invoke(connectionState);
+                        },
+                        default(IntPtr));
+                }
+
+                return new XblRealTimeActivityCallbackToken() { InteropHandlerId = interopHandlerId };
+            }
+
+            public static int XblRealTimeActivityRemoveConnectionStateChangeHandler(
+                XblContextHandle xboxLiveContext,
+                ref XblRealTimeActivityCallbackToken connectionStateChangeCallbackToken)
+            {
+                var result = RealTimeActivity.XblRealTimeActivityRemoveConnectionStateChangeHandler(
+                    xboxLiveContext.InteropHandle.handle,
+                    connectionStateChangeCallbackToken.InteropHandlerId);
+
+                if (HR.SUCCEEDED(result))
+                {
+                    connectionStateChangeCallbackToken.Reset();
+                }
+
+                return result;
+            }
+
+            public static XblRealTimeActivityCallbackToken XblRealTimeActivityAddResyncHandler(
+                XblContextHandle xboxLiveContext,
+                XblConnectionResyncCallback callback)
+            {
+                int interopHandlerId = XblRealTimeActivityCallbackToken.InvalidHandlerId;
+
+                if (callback != null)
+                {
+                    interopHandlerId = RealTimeActivity.XblRealTimeActivityAddResyncHandler(
+                        xboxLiveContext.InteropHandle.handle,
+                        (IntPtr context) =>
+                        {
+                            callback?.Invoke();
+                        },
+                        default(IntPtr));
+                }
+
+                return new XblRealTimeActivityCallbackToken() { InteropHandlerId = interopHandlerId };
+            }
+
+            public static int XblRealTimeActivityRemoveResyncHandler(
+                XblContextHandle xboxLiveContext,
+                ref XblRealTimeActivityCallbackToken connectionResyncCallbackToken)
+            {
+                var result = RealTimeActivity.XblRealTimeActivityRemoveResyncHandler(
+                    xboxLiveContext.InteropHandle.handle,
+                    connectionResyncCallbackToken.InteropHandlerId);
+
+                if (HR.SUCCEEDED(result))
+                {
+                    connectionResyncCallbackToken.Reset();
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs
@@ -22,6 +22,13 @@ namespace XGamingRuntime
     {
         public partial class XBL
         {
+            /// <summary>
+            /// Wraps the underlying native XblRealTimeActivityAddConnectionStateChangeHandler API:
+            /// https://docs.microsoft.com/en-us/gaming/gdk/_content/gc/reference/live/xsapi-c/real_time_activity_c/functions/xblrealtimeactivityaddconnectionstatechangehandler
+            /// </summary>
+            /// <param name="xboxLiveContext"></param>
+            /// <param name="callback"></param>
+            /// <returns>a XblRealTimeActivityCallbackToken with which to remove the callback</returns>
             public static XblRealTimeActivityCallbackToken XblRealTimeActivityAddConnectionStateChangeHandler(
                 XblContextHandle xboxLiveContext,
                 XblConnectionStateChangeCallback callback)
@@ -46,6 +53,13 @@ namespace XGamingRuntime
                 return new XblRealTimeActivityCallbackToken() { InteropHandlerId = interopHandlerId };
             }
 
+            /// <summary>
+            /// Wraps the underlying native XblRealTimeActivityRemoveConnectionStateChangeHandler API:
+            /// https://docs.microsoft.com/en-us/gaming/gdk/_content/gc/reference/live/xsapi-c/real_time_activity_c/functions/xblrealtimeactivityremoveconnectionstatechangehandler
+            /// </summary>
+            /// <param name="xboxLiveContext"></param>
+            /// <param name="connectionStateChangeCallbackToken"></param>
+            /// <returns>HR.S_OK on success, otherwise HR.FAILED(...) is true</returns>
             public static int XblRealTimeActivityRemoveConnectionStateChangeHandler(
                 XblContextHandle xboxLiveContext,
                 ref XblRealTimeActivityCallbackToken connectionStateChangeCallbackToken)
@@ -64,6 +78,13 @@ namespace XGamingRuntime
                 return result;
             }
 
+            /// <summary>
+            /// Wraps the underlying native XblRealTimeActivityAddResyncHandler API:
+            /// https://docs.microsoft.com/en-us/gaming/gdk/_content/gc/reference/live/xsapi-c/real_time_activity_c/functions/xblrealtimeactivityaddresynchandler
+            /// </summary>
+            /// <param name="xboxLiveContext"></param>
+            /// <param name="callback"></param>
+            /// <returns>a XblRealTimeActivityCallbackToken with which to remove the callback</returns>
             public static XblRealTimeActivityCallbackToken XblRealTimeActivityAddResyncHandler(
                 XblContextHandle xboxLiveContext,
                 XblConnectionResyncCallback callback)
@@ -88,6 +109,13 @@ namespace XGamingRuntime
                 return new XblRealTimeActivityCallbackToken() { InteropHandlerId = interopHandlerId };
             }
 
+            /// <summary>
+            /// Wraps the underlying native XblRealTimeActivityRemoveResyncHandler API:
+            /// https://docs.microsoft.com/en-us/gaming/gdk/_content/gc/reference/live/xsapi-c/real_time_activity_c/functions/xblrealtimeactivityremoveresynchandler
+            /// </summary>
+            /// <param name="xboxLiveContext"></param>
+            /// <param name="connectionResyncCallbackToken"></param>
+            /// <returns>HR.S_OK on success, otherwise HR.FAILED(...) is true</returns>
             public static int XblRealTimeActivityRemoveResyncHandler(
                 XblContextHandle xboxLiveContext,
                 ref XblRealTimeActivityCallbackToken connectionResyncCallbackToken)

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe01a589be169f942965b543528fffb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Social.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Social.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9dce99bd28d8e2845899085948ddb02e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Social/XblSocial.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Social/XblSocial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6b45b8d62ee4274e9f228f97e1f08d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
real time activity API method implementations for scripting layer...
... also including missing METAs for previously committed source.

make sure the interop callbacks have a [MonoPInvokeCallback] attribute on them...

fixed another compile error because Unity 2017 is on C# 6.

I am curious if there is a better way to bridge the gap between a native-level "IntPtr" parameter callback that has [MonoPInvokeCallback] and a regular C# delegate callback that is not using unsafe.