### PR TITLE
fix:Only copy dev build settings if the dev build checkbox is checked

### DIFF
--- a/Package/Assets/GDK-APIs/Runtime/Source/User/XUser.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/User/XUser.cs
@@ -409,7 +409,7 @@ namespace XGamingRuntime
             }
 
             // Use wait=true to ensure that it's safe to free the context object.
-            bool _ = XGRInterop.XUserUnregisterForChangeEvent(registrationToken.Token, wait: true);
+            XGRInterop.XUserUnregisterForChangeEvent(registrationToken.Token, wait: true);
             registrationToken.CallbackHandle.Free();
         }
 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Matchmaking/XblMatchmaking.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Matchmaking/XblMatchmaking.cs
@@ -77,9 +77,12 @@ namespace XGamingRuntime
                                 matchTicket.estimatedWaitTime = response.estimatedWaitTime;
                             }
 
-                            createCompletionCallback?.Invoke(
-                                hresult,
-                                matchTicket);
+                            if (createCompletionCallback != null)
+                            {
+                                createCompletionCallback.Invoke(
+                                    hresult,
+                                    matchTicket);
+                            }
                         });
 
                     var scidLen = Converters.GetSizeRequiredToEncodeStringToUTF8(serviceConfigurationId);
@@ -107,9 +110,12 @@ namespace XGamingRuntime
 
                         if (HR.FAILED(result))
                         {
-                            createCompletionCallback?.Invoke(
-                                result,
-                                new XblMatchTicket());
+                            if (createCompletionCallback != null)
+                            {
+                                createCompletionCallback.Invoke(
+                                    result,
+                                    new XblMatchTicket());
+                            }
                         }
                     }
                 }
@@ -132,7 +138,10 @@ namespace XGamingRuntime
                         SDK.defaultQueue.handle,
                         (XAsyncBlockPtr block) =>
                         {
-                            deleteCompletionCallback?.Invoke(HR.S_OK);
+                            if (deleteCompletionCallback != null)
+                            {
+                                deleteCompletionCallback.Invoke(HR.S_OK);
+                            }
                         });
 
                     var scidLen = Converters.GetSizeRequiredToEncodeStringToUTF8(serviceConfigurationId);
@@ -157,7 +166,10 @@ namespace XGamingRuntime
 
                         if (HR.FAILED(result))
                         {
-                            deleteCompletionCallback?.Invoke(result);
+                            if (deleteCompletionCallback != null)
+                            {
+                                deleteCompletionCallback.Invoke(result);
+                            }
                         }
                     }
                 }
@@ -216,7 +228,10 @@ namespace XGamingRuntime
                                 }
                             }
 
-                            completionCallback?.Invoke(hresult, details);
+                            if (completionCallback != null)
+                            { 
+                                completionCallback.Invoke(hresult, details);
+                            }
                         });
 
                     var scidLen = Converters.GetSizeRequiredToEncodeStringToUTF8(serviceConfigurationId);
@@ -241,7 +256,10 @@ namespace XGamingRuntime
 
                         if (HR.FAILED(result))
                         {
-                            completionCallback?.Invoke(result, new XblMatchTicketDetailsResponse());
+                            if (completionCallback != null)
+                            { 
+                                completionCallback.Invoke(result, new XblMatchTicketDetailsResponse());
+                            }
                         }
                     }
                 }
@@ -294,7 +312,10 @@ namespace XGamingRuntime
                                 }
                             }
 
-                            completionCallback?.Invoke(hresult, statistics);
+                            if (completionCallback != null)
+                            { 
+                                completionCallback.Invoke(hresult, statistics);
+                            }
                         });
 
                     var scidLen = Converters.GetSizeRequiredToEncodeStringToUTF8(serviceConfigurationId);
@@ -315,7 +336,10 @@ namespace XGamingRuntime
 
                         if (HR.FAILED(result))
                         {
-                            completionCallback?.Invoke(result, new XblHopperStatisticsResponse());
+                            if (completionCallback != null)
+                            { 
+                                completionCallback.Invoke(result, new XblHopperStatisticsResponse());
+                            }
                         }
                     }
                 }

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Multiplayer/XblMultiplayerHandlers.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Multiplayer/XblMultiplayerHandlers.cs
@@ -177,7 +177,10 @@ namespace XGamingRuntime
                     }
 
                     var eventHandler = _functionIdToHandler[functionId];
-                    eventHandler.Callback?.Invoke();
+                    if (eventHandler.Callback != null)
+                    {
+                        eventHandler.Callback.Invoke();
+                    }
                 }
             }
 
@@ -207,7 +210,10 @@ namespace XGamingRuntime
                     }
 
                     var eventHandler = _functionIdToHandler[functionId];
-                    eventHandler.Callback?.Invoke();
+                    if (eventHandler.Callback != null)
+                    {
+                        eventHandler.Callback.Invoke();
+                    }
                 }
             }
 
@@ -241,7 +247,10 @@ namespace XGamingRuntime
                     }
 
                     var eventHandler = _functionIdToHandler[functionId];
-                    eventHandler.Callback?.Invoke(eventArgs);
+                    if (eventHandler.Callback != null)
+                    {
+                        eventHandler.Callback.Invoke(eventArgs);
+                    }
                 }
             }
         }

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Multiplayer/XblMultiplayerHandlers.cs.meta
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Multiplayer/XblMultiplayerHandlers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74215959061e3d148824c93ae66c49c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Multiplayer/XblMultiplayerSession.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Multiplayer/XblMultiplayerSession.cs
@@ -386,7 +386,7 @@ namespace XGamingRuntime
                         measurementServerAddressesJson);
                     sbyte[] interopJson = new sbyte[requiredInteropLen];
 
-                    fixed(sbyte* interopJsonPtr = &interopJson[0])
+                    fixed (sbyte* interopJsonPtr = &interopJson[0])
                     {
                         Converters.StringToNullTerminatedUTF8FixedPointer(
                             measurementServerAddressesJson, (byte*)interopJsonPtr, requiredInteropLen);
@@ -607,7 +607,7 @@ namespace XGamingRuntime
 
                 unsafe
                 {
-                    var interopServerJsonLen = 
+                    var interopServerJsonLen =
                         string.IsNullOrEmpty(rawServersJson) ? 1 :
                         Converters.GetSizeRequiredToEncodeStringToUTF8(
                             rawServersJson);
@@ -758,7 +758,7 @@ namespace XGamingRuntime
                     var connectionPath = new sbyte[connectionPathLen];
                     connectionPath[0] = 0;
 
-                    fixed(sbyte* connectionPathPtr = &connectionPath[0])
+                    fixed (sbyte* connectionPathPtr = &connectionPath[0])
                     {
                         if (!string.IsNullOrEmpty(serverConnectionPath))
                         {
@@ -882,8 +882,8 @@ namespace XGamingRuntime
                         if (!string.IsNullOrEmpty(measurements))
                         {
                             Converters.StringToNullTerminatedUTF8FixedPointer(
-                                measurements, 
-                                (byte*)interopMeasurementsPtr, 
+                                measurements,
+                                (byte*)interopMeasurementsPtr,
                                 interopMeasurementsLen);
                         }
 
@@ -1012,7 +1012,7 @@ namespace XGamingRuntime
                     var interopJson = new sbyte[interopJsonLen];
                     interopJson[0] = 0;
 
-                    fixed(sbyte* interopJsonPtr = &interopJson[0])
+                    fixed (sbyte* interopJsonPtr = &interopJson[0])
                     {
                         if (!string.IsNullOrEmpty(matchmakingTargetSessionConstantsJson))
                         {
@@ -1169,7 +1169,10 @@ namespace XGamingRuntime
 
                             var resultSessionHandle = new XblMultiplayerSessionHandle(
                                 new Interop.XblMultiplayerSessionHandle() { handle = handle });
-                            completionCallback?.Invoke(hresult, resultSessionHandle);
+                            if (completionCallback != null)
+                            {
+                                completionCallback.Invoke(hresult, resultSessionHandle);
+                            }
                         }
                     });
 
@@ -1221,7 +1224,10 @@ namespace XGamingRuntime
 
                             var resultSessionHandle = new XblMultiplayerSessionHandle(
                                 new Interop.XblMultiplayerSessionHandle() { handle = handle });
-                            completionCallback?.Invoke(hresult, resultSessionHandle);
+                            if (completionCallback != null)
+                            {
+                                completionCallback.Invoke(hresult, resultSessionHandle);
+                            }
                         }
                     });
 
@@ -1263,7 +1269,10 @@ namespace XGamingRuntime
 
                             var resultSessionHandle = new XblMultiplayerSessionHandle(
                                 new Interop.XblMultiplayerSessionHandle() { handle = handle });
-                            completionCallback?.Invoke(hresult, resultSessionHandle);
+                            if (completionCallback != null)
+                            {
+                                completionCallback.Invoke(hresult, resultSessionHandle);
+                            }
                         }
                     });
 
@@ -1307,7 +1316,10 @@ namespace XGamingRuntime
                     SDK.defaultQueue.handle,
                     (XAsyncBlockPtr block) =>
                     {
-                        completionCallback?.Invoke(HR.S_OK);
+                        if (completionCallback != null)
+                        {
+                            completionCallback.Invoke(HR.S_OK);
+                        }
                     });
 
                 unsafe
@@ -1343,7 +1355,10 @@ namespace XGamingRuntime
                     SDK.defaultQueue.handle,
                     (XAsyncBlockPtr block) =>
                     {
-                        completionCallback?.Invoke(HR.S_OK);
+                        if (completionCallback != null)
+                        {
+                            completionCallback.Invoke(HR.S_OK);
+                        }
                     });
 
                 unsafe
@@ -1412,7 +1427,10 @@ namespace XGamingRuntime
 
                                 }
 
-                                completionCallback?.Invoke(hresult, handles);
+                                if (completionCallback != null)
+                                {
+                                    completionCallback.Invoke(hresult, handles);
+                                }
                             }
                         }
                     });
@@ -1569,8 +1587,8 @@ namespace XGamingRuntime
                     fixed (sbyte* interopRoleTypeNamePtr = &interopRoleTypeName[0], interopRoleNamePtr = &interopRoleName[0])
                     {
                         Converters.StringToNullTerminatedUTF8FixedPointer(
-                            roleTypeName, 
-                            (byte*)interopRoleTypeNamePtr, 
+                            roleTypeName,
+                            (byte*)interopRoleTypeNamePtr,
                             interopRoleTypeNameLen);
 
                         Converters.StringToNullTerminatedUTF8FixedPointer(
@@ -1585,7 +1603,7 @@ namespace XGamingRuntime
                             &rolePtr);
                     }
 
-                    if(HR.SUCCEEDED(result) && rolePtr != default(Interop.XblMultiplayerRole*))
+                    if (HR.SUCCEEDED(result) && rolePtr != default(Interop.XblMultiplayerRole*))
                     {
                         role = new XblMultiplayerRole(*rolePtr);
                     }

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/RealTimeActivity/XblRealTimeActivity.cs
@@ -166,7 +166,10 @@ namespace XGamingRuntime
                     }
 
                     var eventHandler = _functionIdToHandler[functionId];
-                    eventHandler.Callback?.Invoke(newConnectionState);
+                    if (eventHandler.Callback != null)
+                    { 
+                        eventHandler.Callback.Invoke(newConnectionState);
+                    }
                 }
             }
 
@@ -196,7 +199,10 @@ namespace XGamingRuntime
                     }
 
                     var eventHandler = _functionIdToHandler[functionId];
-                    eventHandler.Callback?.Invoke();
+                    if (eventHandler.Callback != null)
+                    { 
+                        eventHandler.Callback.Invoke();
+                    }
                 }
             }
         }

--- a/Package/Assets/GDK-APIs/Runtime/Source/XBL/Social/XblSocial.cs
+++ b/Package/Assets/GDK-APIs/Runtime/Source/XBL/Social/XblSocial.cs
@@ -64,7 +64,10 @@ namespace XGamingRuntime
                             var result = Social.XblSocialGetSocialRelationshipsResult(block, &handle);
 
                             var socialHandle = new XblSocialHandle { interopHandle = handle };
-                            completionCallback?.Invoke(result, socialHandle);
+                            if (completionCallback != null)
+                            { 
+                                completionCallback.Invoke(result, socialHandle);
+                            }
                         }
                     });
 
@@ -78,7 +81,10 @@ namespace XGamingRuntime
 
                 if (HR.FAILED(hresult))
                 {
-                    completionCallback?.Invoke(hresult, default(XblSocialHandle));
+                    if (completionCallback != null)
+                    { 
+                        completionCallback.Invoke(hresult, default(XblSocialHandle));
+                    }
                 }
 
                 return hresult;
@@ -221,7 +227,10 @@ namespace XGamingRuntime
                             var result = Social.XblSocialRelationshipResultGetNextResult(block, &handle);
 
                             var refreshedHandle = new XblSocialHandle { interopHandle = handle };
-                            completionCallback?.Invoke(result, refreshedHandle);
+                            if (completionCallback != null)
+                            { 
+                                completionCallback.Invoke(result, refreshedHandle);
+                            }
                         }
                     });
 
@@ -233,7 +242,10 @@ namespace XGamingRuntime
 
                 if (HR.FAILED(hresult))
                 {
-                    completionCallback?.Invoke(hresult, default(XblSocialHandle));
+                    if (completionCallback != null)
+                    { 
+                        completionCallback.Invoke(hresult, default(XblSocialHandle));
+                    }
                 }
 
                 return hresult;
@@ -385,7 +397,10 @@ namespace XGamingRuntime
                         idsPtr++;
                     }
 
-                    eventHandler.Callback?.Invoke(callbackEventArgs);
+                    if (eventHandler.Callback != null)
+                    { 
+                        eventHandler.Callback.Invoke(callbackEventArgs);
+                    }
                 }
             }
         }

--- a/Package/Assets/GDK-Tools/Source/Editor/GdkBuild.cs
+++ b/Package/Assets/GDK-Tools/Source/Editor/GdkBuild.cs
@@ -308,38 +308,39 @@ public static class GdkBuild
         // Switch the platform to Win32, x64. The GDK only supports x64.
         BuildTarget buildTarget = BuildTarget.StandaloneWindows64;
         EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.Standalone, buildTarget);
-        if (EditorUserBuildSettings.allowDebugging)
+        if (EditorUserBuildSettings.development)
         {
-            buildOptions |= BuildOptions.AllowDebugging;
-        }
-        if (EditorUserBuildSettings.buildScriptsOnly)
-        {
-            buildOptions |= BuildOptions.BuildScriptsOnly;
-        }
+            buildOptions |= BuildOptions.Development;
+
+            if (EditorUserBuildSettings.allowDebugging)
+            {
+                buildOptions |= BuildOptions.AllowDebugging;
+            }
+            if (EditorUserBuildSettings.buildScriptsOnly)
+            {
+                buildOptions |= BuildOptions.BuildScriptsOnly;
+            }
 #if UNITY_2019_3_OR_NEWER
             if (EditorUserBuildSettings.buildWithDeepProfilingSupport)
             {
                 buildOptions |= BuildOptions.EnableDeepProfilingSupport;
             }
 #endif
-        if (EditorUserBuildSettings.connectProfiler)
-        {
-            buildOptions |= BuildOptions.ConnectWithProfiler;
-        }
-        if (EditorUserBuildSettings.development)
-        {
-            buildOptions |= BuildOptions.Development;
-        }
-        if (EditorUserBuildSettings.enableHeadlessMode)
-        {
-            buildOptions |= BuildOptions.EnableHeadlessMode;
-        }
+            if (EditorUserBuildSettings.connectProfiler)
+            {
+                buildOptions |= BuildOptions.ConnectWithProfiler;
+            }
 #if UNITY_2019_1_OR_NEWER
             if (EditorUserBuildSettings.waitForPlayerConnection)
             {
                 buildOptions |= BuildOptions.WaitForPlayerConnection;
             }
 #endif
+        }
+        if (EditorUserBuildSettings.enableHeadlessMode)
+        {
+            buildOptions |= BuildOptions.EnableHeadlessMode;
+        }
 
         return buildOptions;
     }

--- a/Package/Assets/GDK-Tools/Source/Scripts/Gdk.cs
+++ b/Package/Assets/GDK-Tools/Source/Scripts/Gdk.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Xbox
 
             _associatedProducts = new List<XStoreProduct>();
             _queryAssociatedProductsCallback = callback;
-            int hresult = SDK.XStoreCreateContext(out _storeContext);
+            Succeeded(SDK.XStoreCreateContext(out _storeContext), "Failed to create store context.");
             SDK.XStoreQueryAssociatedProductsAsync(
                 _storeContext,
                 _addOnProducts,

--- a/Package/Assets/GDK-Tools/Source/Scripts/XGameSaveWrapper.cs
+++ b/Package/Assets/GDK-Tools/Source/Scripts/XGameSaveWrapper.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. InitializeCallback(Int32 hresult)</param>
         public void InitializeAsync(XUserHandle userHandle, string scid, InitializeCallback callback)
         {
+            m_userHandle = null;
+            m_gameSaveProviderHandle = null;
 #if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             Int32 hr = SDK.XUserDuplicateHandle(userHandle, out m_userHandle);
             if (HR.FAILED(hr))

--- a/Package/Assets/GDK-Tools/Source/Scripts/XGameSaveWrapper.cs
+++ b/Package/Assets/GDK-Tools/Source/Scripts/XGameSaveWrapper.cs
@@ -47,8 +47,10 @@ namespace Microsoft.Xbox
         /// <param name="callback">Callback invoked when the async task completes. InitializeCallback(Int32 hresult)</param>
         public void InitializeAsync(XUserHandle userHandle, string scid, InitializeCallback callback)
         {
+#if (MICROSOFT_GAME_CORE || UNITY_GAMECORE)
             m_userHandle = null;
             m_gameSaveProviderHandle = null;
+#endif
 #if (MICROSOFT_GAME_CORE || UNITY_GAMECORE) && !UNITY_EDITOR
             Int32 hr = SDK.XUserDuplicateHandle(userHandle, out m_userHandle);
             if (HR.FAILED(hr))


### PR DESCRIPTION
This change:
* Fixes issue #66 - we only copy dev-build related settings if the dev build checkbox is checked
* Fixes to keep compatibility with Unity 2017
* Also fixes warnings about inconsistent line endings and unassigned variables