### PR TITLE
Preventing innocuous XblInitialize error on repeated in-editor playing

### DIFF
--- a/Package/Assets/GDK-Tools/Source/Editor/GdkPlugin.cs
+++ b/Package/Assets/GDK-Tools/Source/Editor/GdkPlugin.cs
@@ -8,6 +8,7 @@ using UnityEditor;
 using UnityEngine;
 
 using Debug = UnityEngine.Debug;
+using XGamingRuntime;
 
 namespace Microsoft.GameCore.Tools
 {
@@ -17,16 +18,24 @@ namespace Microsoft.GameCore.Tools
         static GdkPlugin()
         {
             GdkUtilities.PullGdkDlls();
-            EditorApplication.playModeStateChanged += PullGdkDlls;
+#if MICROSOFT_GAME_CORE
+            EditorApplication.playModeStateChanged += OnPlayModeChange;
+#endif
         }
 
-        private static void PullGdkDlls(PlayModeStateChange state)
+#if MICROSOFT_GAME_CORE
+        private static void OnPlayModeChange(PlayModeStateChange state)
         {
             if (state == PlayModeStateChange.ExitingEditMode)
             {
                 GdkUtilities.PullGdkDlls();
             }
+            else if (state == PlayModeStateChange.ExitingPlayMode)
+            {
+                SDK.XBL.XblCleanup((int hresult) => { });
+            }
         }
+#endif
 
         [MenuItem("GDK/Documentation/Developer Portal (GDK)")]
         private static void OpenDeveloperPortal()


### PR DESCRIPTION
When starting a game in-editor multiple times in a row, you were likely to see an "Initialize Xbox Live failed" because XBL would've already been initialized the first time you hit play, and it's unlikely the game itself would call XblCleanup when stopping play via the editor. This wouldn't necessarily have caused a real problem as XBL would actually still be correctly initialized from before, but it could've resulted in odd behavior if certain services remained active.

This ensures cleanup happens when leaving "play" so that XBL really does get a fresh initialize each time.