### PR TITLE
Fixed issue where debug folder added to build, and thus failing cert on GDK PC builds

### DIFF
--- a/Package/Assets/GDK-Tools/Source/Editor/GdkBuild.cs
+++ b/Package/Assets/GDK-Tools/Source/Editor/GdkBuild.cs
@@ -374,7 +374,7 @@ public static class GdkBuild
 
         var doc = XDocument.Load(layoutPath);
         var ignoredNodes = (from node in doc.Descendants()
-                            where node.Name == "FileGroup" && node.Attribute("SourcePath").Value.Contains("Package_BackUpThisFolder_ButDontShipItWithYourGame")
+                            where node.Name == "FileGroup" && node.Attribute("SourcePath").Value.Contains("BackUpThisFolder_ButDontShipItWithYourGame")
                             select node).ToArray();
 
         for (int i = 0; i < ignoredNodes.Length; ++i)


### PR DESCRIPTION
The build script searched for the string: "Package_BackUpThisFolder_ButDontShipItWithYourGame" to ignore, but this folder was never found due to the project name replacing 'Package'. The script now just searches for: "BackUpThisFolder_ButDontShipItWithYourGame". This produced a successful validation.