### PR TITLE
Prevent the 'MicrosoftGame.Config' file from being inserted when not WinGDK

### DIFF
--- a/Package/Assets/GDK-Tools/Source/Editor/GdkBuild.cs
+++ b/Package/Assets/GDK-Tools/Source/Editor/GdkBuild.cs
@@ -460,7 +460,9 @@ public class GdkPostBuild : IPostprocessBuildWithReport
 
     public void OnPostprocessBuild(BuildReport report)
     {
+#if MICROSOFT_GAME_CORE
         File.Copy(GdkUtilities.GameConfigPath, Path.Combine(Path.GetDirectoryName(report.summary.outputPath), Path.GetFileName(GdkUtilities.GameConfigPath)), true);
+#endif
     }
 }
 #else
@@ -470,7 +472,9 @@ public class GdkPostBuild : IPostprocessBuild
 
     public void OnPostprocessBuild(BuildTarget target, string outputPath)
     {
+#if MICROSOFT_GAME_CORE
         File.Copy(GdkUtilities.GameConfigPath, Path.Combine(Path.GetDirectoryName(outputPath), Path.GetFileName(GdkUtilities.GameConfigPath)), true);
+#endif
     }
 }
 #endif


### PR DESCRIPTION
Hello,

this OnPostprocessBuild() call always copy the 'MicrosoftGame.Config' file into the output folders for any platform.
This interferes with custom build processes for other PC outputs and proprietary platforms, by inserting a file that is not necessary for those configurations, and allows a properly configured multi-platform development environment.

This PR restricts the execution of the OnPostprocessBuild() to only when the platform define MICROSOFT_GAME_CORE is actually defined.

If there's a need to having this package to work even if the MICROSOFT_GAME_CORE is not defined, please, consider finding an alternative way to insert the MicrosoftGame.Config file that does not runs during a non-PC platform.

Thank you